### PR TITLE
scripts: replace host + port parameters to just host

### DIFF
--- a/scripts/wait_for_targets.py
+++ b/scripts/wait_for_targets.py
@@ -35,10 +35,10 @@ def put(url, data):
         print response
         return False
 
-def run(targets, hostname, port):
+def run(targets, hostname):
     run = True
     while run:
-        client_list_url = 'http://%s:%s/api/clients'  % (hostname, port)
+        client_list_url = '%s/api/clients'  % (hostname)
         response = get(client_list_url)
         if response:
             if len(response) >= targets:
@@ -52,10 +52,9 @@ def main():
     description = 'Simple Leshan API Wrapper for waiting for targets to connect'
     parser = argparse.ArgumentParser(version=__version__, description=description)
     parser.add_argument('-t', '--targets', help='Number of Leshan Targets to wait for', type=int, required=True)
-    parser.add_argument('-host', '--hostname', help='Leshan Server Hostname or IP', default='leshan')
-    parser.add_argument('-port', '--port', help='Leshan Server Port', default='8080')
+    parser.add_argument('-host', '--hostname', help='Leshan Server URL', default='https://mgmt.foundries.io/leshan')
     args = parser.parse_args()
-    run(args.targets, args.hostname, args.port)
+    run(args.targets, args.hostname)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Each script was accepting 2 parameters for host and port and then
assembling the URL for the Leshan API.  This doesn't work for servers
which have the leshan API under a sub-directory like so:
https://mgmt.foundries.io:80/leshan

Instead, simplify to 1 parameter for the entire URL base which
includes the protocol, hostname, port and if needed a sub-directory
without ending slash.

Signed-off-by: Michael Scott <mike@foundries.io>