### PR TITLE
Fix the format for the product id when device inits

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -96,7 +96,7 @@ void main(void)
 	app_wq_init();
 
 	LOG_INF("Open Source Foundries FOTA LWM2M example application");
-	LOG_INF("Device: %s, Serial: %x",
+	LOG_INF("Device: %s, Serial: %08x",
 		product_id_get()->name, product_id_get()->number);
 
 	TC_START("Running Built in Self Test (BIST)");


### PR DESCRIPTION
Previously, a product id such as 019d2cd1 was being displayed:
<inf> fota_main: Device: nrf52_blenano2, Serial: 19d2cd1

With this patch:
<inf> fota_main: Device: nrf52_blenano2, Serial: 019d2cd1

NOTE: leading 0's will be preserved and not break CI scripts.

Signed-off-by: Michael Scott <mike@foundries.io>