### PR TITLE
dm-lwm2m: replace application_state w/ generic settings storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/lib)
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE src/app_work_queue.c)
 target_sources(app PRIVATE src/lwm2m.c)
+target_sources(app PRIVATE src/settings.c)
 target_sources(app PRIVATE src/light_control.c)
 target_sources_ifdef(CONFIG_NET_L2_BT        app PRIVATE src/bluetooth.c)
 

--- a/boards/common-nrf52832.overlay
+++ b/boards/common-nrf52832.overlay
@@ -1,9 +1,14 @@
 &flash0 {
 	partitions {
-		/* Persistent state the application modifies. */
-		app_state_partition: partition@7d000 {
-			label = "application-state";
-			reg = <0x0007d000 0x2000>;
+		/*
+		 * For most devices we have a storage partition defined,
+		 * and here we are shrinking it slightly to make room for
+		 * 1 additional partition.  In the case of Nitrogen there
+		 * is no storage partition defined.
+		 */
+		storage_partition: partition@7a000 {
+			label = "storage";
+			reg = <0x0007a000 0x00005000>;
 		};
 
 		/* DTLS credentials etc. */

--- a/boards/common-nrf52840.overlay
+++ b/boards/common-nrf52840.overlay
@@ -1,8 +1,12 @@
 &flash0 {
 	partitions {
-		app_state_partition: partition@fd000 {
-			label = "application-state";
-			reg = <0x000fd000 0x2000>;
+		/*
+		 * Shrink the storage partition slightly to make room for
+		 * credentials partition.
+		 */
+		storage_partition: partition@fc000 {
+			label = "storage";
+			reg = <0x000fc000 0x00003000>;
 		};
 
 		credentials_partition: partition@ff000 {

--- a/boards/frdm_k64f.overlay
+++ b/boards/frdm_k64f.overlay
@@ -1,13 +1,8 @@
 &flash0 {
 	partitions {
-		app_state_partition: partition@10000 {
-			label = "application-state";
-			reg = <0x00010000 0x0000f000>;
-		};
-
-		credentials_partition: partition@1f000 {
+		credentials_partition: partition@10000 {
 			label = "lwm2m-credentials";
-			reg = <0x0001f000 0x00001000>;
+			reg = <0x00010000 0x00001000>;
 		};
 	};
 };

--- a/prj.conf
+++ b/prj.conf
@@ -19,9 +19,10 @@ CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_FOTA_DEVICE=y
 CONFIG_IMG_MANAGER=y
 CONFIG_MCUBOOT_IMG_MANAGER=y
-# We don't use the upstream flash storage partition when it exists, so
-# allocate its flash space to our application.
-# CONFIG_FS_FLASH_STORAGE_PARTITION is not set
+# Enable settings storage
+CONFIG_SETTINGS=y
+CONFIG_FCB=y
+CONFIG_SETTINGS_FCB=y
 
 # CONFIG
 CONFIG_NET_CONFIG_SETTINGS=y

--- a/src/main.c
+++ b/src/main.c
@@ -16,12 +16,14 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <gpio.h>
 #include <net/lwm2m.h>
 #include <tc_util.h>
+#include <settings/settings.h>
 
 /* Local helpers and functions */
 #include "app_work_queue.h"
 #include "product_id.h"
 #include "lwm2m.h"
 #include "light_control.h"
+#include "settings.h"
 
 /* Defines and configs for the IPSO elements */
 #define TEMP_DEV		"fota-temp"
@@ -119,6 +121,17 @@ void main(void)
 		return;
 	}
 	_TC_END_RESULT(TC_PASS, "init_light_control");
+
+	TC_PRINT("Initializing FOTA settings\n");
+	if (fota_settings_init()) {
+		_TC_END_RESULT(TC_FAIL, "fota_settings_init");
+		TC_END_REPORT(TC_FAIL);
+	}
+	_TC_END_RESULT(TC_PASS, "fota_settings_init");
+
+	/* Load *all* persistent settings */
+	settings_load();
+
 	TC_END_REPORT(TC_PASS);
 
 	if (lwm2m_init(app_work_q)) {

--- a/src/settings.c
+++ b/src/settings.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019 Foundries.io
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define LOG_MODULE_NAME fota_storage
+#define LOG_LEVEL CONFIG_FOTA_LOG_LEVEL
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include <zephyr.h>
+#include <settings/settings.h>
+
+#include "settings.h"
+
+static struct update_counter uc;
+
+int fota_update_counter_read(struct update_counter *update_counter)
+{
+	memcpy(update_counter, &uc, sizeof(uc));
+	return 0;
+}
+
+int fota_update_counter_update(update_counter_t type, u32_t new_value)
+{
+	if (type == COUNTER_UPDATE) {
+		uc.update = new_value;
+	} else {
+		uc.current = new_value;
+	}
+
+	return settings_save_one("fota/counter", &uc, sizeof(uc));
+}
+
+static int set(int argc, char **argv, void *val_ctx)
+{
+	int len;
+
+	if (argc != 1) {
+		return -ENOENT;
+	}
+
+	if (!strcmp(argv[0], "counter")) {
+		len = settings_val_read_cb(val_ctx, &uc, sizeof(uc));
+		if (len < sizeof(uc)) {
+			LOG_ERR("Unable to read update counter.  Resetting.");
+			memset(&uc, 0, sizeof(uc));
+		}
+
+		return 0;
+	}
+
+	return -ENOENT;
+}
+
+static struct settings_handler fota_settings = {
+	.name = "fota",
+	.h_set = set,
+};
+
+int fota_settings_init(void)
+{
+	int err;
+
+	err = settings_subsys_init();
+	if (err) {
+		LOG_ERR("settings_subsys_init failed (err %d)", err);
+		return err;
+	}
+
+	err = settings_register(&fota_settings);
+	if (err) {
+		LOG_ERR("settings_register failed (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Foundries.io
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FOTA_STORAGE_H__
+#define FOTA_STORAGE_H__
+
+struct update_counter {
+	int current;
+	int update;
+};
+
+typedef enum {
+	COUNTER_CURRENT = 0,
+	COUNTER_UPDATE,
+} update_counter_t;
+
+int fota_update_counter_read(struct update_counter *update_counter);
+int fota_update_counter_update(update_counter_t type, u32_t new_value);
+int fota_settings_init(void);
+
+#endif	/* FOTA_STORAGE_H__ */


### PR DESCRIPTION
Let's replace the application_state partition (which stores the update
counter data) with generic FCB-based settings storage.  This is not
only a clean generic way of saving state for the FOTA application,
but also in the future LwM2M will use this same partition to store
persisted values from the objects.

Signed-off-by: Michael Scott <mike@foundries.io>