### PR TITLE
dm-lwm2m: move to radvd / NAT64 settings

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -88,16 +88,16 @@ config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
 	default y
 
 config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR
-	default "coap://[fe80::d4e7:0:0:1]:5682"
+	default "coap://[fd11:11::1]:5682"
 
 config NET_CONFIG_PEER_IPV6_ADDR
-	default "fe80::d4e7:0:0:1"
+	default "64:ff9b::c6c7:6c9f"
 
 config NET_L2_BT
 	default y
 
 config NET_CONFIG_INIT_TIMEOUT
-	default 0
+	default 30
 
 config BT_RX_BUF_COUNT
 	default 10


### PR DESCRIPTION
- Radvd for bt0 establishes an fd11:11:: subnet for BLE 6lowpan nodes.
  it also self assigns fd11:11::1 IP to the gateway for services
  provided by the gateway: coap-http proxy, DNS, etc.
  Let's use the fd11:11::1 IP for coap-http proxy as this is still
  needed to translate CoAP packets to HTTP for easy firmware downloads.
- Now that we can actually route traffic to anywhere, let's use the
  6-to-4 variant of mgmt.foundries.io (198.199.108.159 ->
  64:ff9b::c6c7:6c9f)
  NOTE: later this will be replaced by "mgmt.foundries.io" once DNS
  is enabled.
- Set network initialization timeout to 30 seconds which gives time
  for radvd to complete router advertisement process.

Signed-off-by: Michael Scott <mike@foundries.io>