### PR TITLE
dm-lwm2m: print device, serial and BT MAC during BT init

### DIFF
--- a/src/bluetooth.c
+++ b/src/bluetooth.c
@@ -98,11 +98,17 @@ static int bt_network_init(struct device *dev)
 	int ret = 0;
 
 	/* Storage used to provide a BT MAC based on the serial number */
-	LOG_DBG("Setting Bluetooth MAC\n");
+	LOG_INF("Setting Bluetooth MAC");
 
 	memset(&bt_addr, 0, sizeof(bt_addr_le_t));
 	bt_addr.type = BT_ADDR_LE_RANDOM;
 	set_own_bt_addr(&bt_addr);
+	/* MAC is stored in network order, so print reversed */
+	LOG_INF("Bluetooth MAC: %02x:%02x:%02x:%02x:%02x:%02x",
+		bt_addr.a.val[5], bt_addr.a.val[4], bt_addr.a.val[3],
+		bt_addr.a.val[2], bt_addr.a.val[1], bt_addr.a.val[0]);
+	LOG_INF("Device: %s, Serial: %08x",
+		product_id_get()->name, product_id_get()->number);
 	ret = bt_set_id_addr(&bt_addr);
 	bt_conn_cb_register(&conn_callbacks);
 


### PR DESCRIPTION
This is useful for CI automation as we may need this information
to create a white list of devices.

Signed-off-by: Michael Scott <mike@foundries.io>