### PR TITLE
dm-lwm2m: set OpenThread IPv6 CoAP proxy address

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -90,6 +90,7 @@ config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
 	default y
 
 config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR
+	default "coap://[fd11:22::1]:5682" if NET_L2_OPENTHREAD
 	default "coap://[fd11:11::1]:5682"
 
 config NET_L2_BT


### PR DESCRIPTION
Currently, the CoAP proxy address is only set correctly for BLE
6lowpan devices which use the fd11:11:: network.  OpenThread is
setup for fd11:22:: and should be configured as such.

Signed-off-by: Michael Scott <mike@foundries.io>